### PR TITLE
FIX CHROMEDRIVER 80

### DIFF
--- a/ms_rewards.py
+++ b/ms_rewards.py
@@ -230,15 +230,15 @@ def download_driver(driver_path, system):
     r = requests.get(url)
     latest_version = r.text
     if system == "Windows":
-        url = "https://chromedriver.storage.googleapis.com/{}/chromedriver_win32.zip".format(
+        url = "https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_win32.zip".format(
             latest_version
         )
     elif system == "Darwin":
-        url = "https://chromedriver.storage.googleapis.com/{}/chromedriver_mac64.zip".format(
+        url = "https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_mac64.zip".format(
             latest_version
         )
     elif system == "Linux":
-        url = "https://chromedriver.storage.googleapis.com/{}/chromedriver_linux64.zip".format(
+        url = "https://chromedriver.storage.googleapis.com/79.0.3945.36/chromedriver_linux64.zip".format(
             latest_version
         )
 

--- a/runbot.bat
+++ b/runbot.bat
@@ -1,4 +1,3 @@
-git pull
 python redditScrape.py
 python ms_rewards.py --headless --mobile --pc --quiz
 exit

--- a/runbot.sh
+++ b/runbot.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-git pull
 python3 redditScrape.py
 python3 ms_rewards.py --headless --mobile --pc --quiz
 exit


### PR DESCRIPTION
Currently, Chromedriver 80 is not supported. I adjusted the download path and passed directly to the Chromedriver 79 download link.

Git Pull removed as long as the pull was not performed. After pull please add "Git Pull" to the bat file again and in the run.sh